### PR TITLE
Add parallel build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ if [ ! -d "$node_dir/debian" ]; then
 fi
 
 cd "$node_dir"
-dpkg-buildpackage -j 8
+dpkg-buildpackage -j8
 
 cd -
 ls -l nodejs_*deb

--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ if [ ! -d "$node_dir/debian" ]; then
 fi
 
 cd "$node_dir"
-dpkg-buildpackage
+dpkg-buildpackage -j 8
 
 cd -
 ls -l nodejs_*deb


### PR DESCRIPTION
Currently the build is kind of slow because it doesn't use parallel make.

This pull request introduces 8 concurrent compiler instances. Make auto-decides what can be built in parallel.

I'm not sure about the exact number of parallel threads, it depends on the computer -- 8 seems to be a good tradeoff for me and guarantees a 100% CPU load on my dualcore hyperthreading-capable laptop.
