### PR TITLE
Move parallel-build option from rules file to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -49,7 +49,7 @@ if [ ! -d "$node_dir/debian" ]; then
 fi
 
 cd "$node_dir"
-dpkg-buildpackage $srcdeb -uc
+dpkg-buildpackage $srcdeb -uc -j6
 
 cd -
 

--- a/deb/rules
+++ b/deb/rules
@@ -19,7 +19,7 @@ build: build-stamp
 build-stamp: configure-stamp  
 	dh_testdir
 	# Add here commands to compile the package.
-	$(MAKE) -j6
+	$(MAKE)
 	touch $@
 
 


### PR DESCRIPTION
Sorry for the long delay, this is the change requested by you (see https://github.com/mark-webster/node-debian/pull/8 )
