### PR TITLE
Don't fail build script for successful .deb build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,7 @@ if [ ! -d "$node_dir/debian" ]; then
 	echo "Extracting $node_tar ..."
 	mkdir -p "$node_dir"
 	tar zxf "$node_tar" --strip-components=1 -C "$node_dir"
-	
+
 	echo "Creating $node_dir/debian ..."
 	cp -a deb "$node_dir/debian"
 	sed -e "s/\${VERSION}/${VERSION}/" deb/changelog > "$node_dir/debian/changelog"
@@ -53,6 +53,8 @@ dpkg-buildpackage $srcdeb -uc -j6
 
 cd -
 
-[ "$srcdeb" = "" ]   && ls -l nodejs_*deb
-[ "$srcdeb" = "-S" ] && ls -l nodejs_*
-
+if [ "$srcdeb" = "" ]; then
+	ls -l nodejs_*deb
+elif [ "$srcdeb" = "-S" ]; then
+	ls -l nodejs_*
+fi


### PR DESCRIPTION
Due to the source code check being last in the script, the script would exit with a failure code even if a .deb file was successfully created (which can cause make or other build processes to fail). This change will ensure that only the exit code of the `ls` statement is used.
